### PR TITLE
Remove `await` before `readFileSync`

### DIFF
--- a/src/aurora.ts
+++ b/src/aurora.ts
@@ -33,7 +33,7 @@ async function main(argv: string[], env: NodeJS.ProcessEnv) {
     .option("--upgrade-delay <blocks>", "specify upgrade delay block count", '0')
     .action(async (contractPath, options, command) => {
       const [config, engine] = await loadConfig(command, options, env);
-      const contractCode = await readFileSync(contractPath);
+      const contractCode = readFileSync(contractPath);
       // TODO: combine these both into a single transaction:
       const transactionID1 = (await engine.install(contractCode)).unwrap();
       if (config.verbose || config.debug) console.log(transactionID1);


### PR DESCRIPTION
Hi Arto!! I'm using this code as guide to implement another CLI. Beautiful code.
Found an "await" before "readFileSync". It works anyway, does not cause problems, but just sounds contradictory, so I took the liberty of removing it :)