### PR TITLE
Fix require issue

### DIFF
--- a/lib/aurora.js
+++ b/lib/aurora.js
@@ -3,7 +3,7 @@
 import { AccountID, Address, Engine, base58ToHex, formatU256, ethErc20ToNep141, } from '@aurora-is-near/engine';
 import { program } from 'commander';
 import { readFileSync } from 'fs';
-const { Table } = require('console-table-printer');
+import { Table } from 'console-table-printer';
 main(process.argv, process.env);
 async function main(argv, env) {
     program


### PR DESCRIPTION
When I try to run `aurora`, this error pops up:

```
const { Table } = require('console-table-printer');
                  ^

ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/home/work/.npm-global/lib/node_modules/@aurora-is-near/cli/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///home/work/.npm-global/lib/node_modules/@aurora-is-near/cli/lib/aurora.js:6:19
    at ModuleJob.run (internal/modules/esm/module_job.js:169:25)
    at async Loader.import (internal/modules/esm/loader.js:177:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
```

Replacing `require` with `import` fixes this issue