### PR TITLE
Bump the Aurora.js dependency

### DIFF
--- a/lib/aurora.js
+++ b/lib/aurora.js
@@ -68,7 +68,7 @@ async function main(argv, env) {
         .command('get-bridge-prover')
         .action(async (options, command) => {
         const [_, engine] = await loadConfig(command, options, env);
-        const accountID = (await engine.getBridgeProvider()).unwrap();
+        const accountID = (await engine.getBridgeProver()).unwrap();
         const p = new Table();
         p.addRow({ bridge_prover: accountID.toString() });
         p.printTable();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auroraisnear/cli",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Aurora Engine command-line interface (CLI).",
   "type": "module",
   "module": "lib/aurora.js",
@@ -40,7 +40,7 @@
   "repository": "https://github.com/aurora-is-near/aurora-cli.git",
   "dependencies": {
     "console-table-printer": "^2.9.0",
-    "@aurora-is-near/engine": "aurora-is-near/aurora.js#ee7dd4c",
+    "@aurora-is-near/engine": "aurora-is-near/aurora.js#f0b6478",
     "commander": "^7.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@aurora-is-near/engine': aurora-is-near/aurora.js#ee7dd4c
+  '@aurora-is-near/engine': aurora-is-near/aurora.js#f0b6478
   '@tsconfig/node16': ^1.0.3
   '@types/jest': ^28.1.6
   '@types/node': ^16.11.7
@@ -17,7 +17,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  '@aurora-is-near/engine': github.com/aurora-is-near/aurora.js/ee7dd4c
+  '@aurora-is-near/engine': github.com/aurora-is-near/aurora.js/f0b6478
   commander: 7.2.0
   console-table-printer: 2.11.0
 
@@ -3409,8 +3409,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/aurora-is-near/aurora.js/ee7dd4c:
-    resolution: {tarball: https://codeload.github.com/aurora-is-near/aurora.js/tar.gz/ee7dd4c}
+  github.com/aurora-is-near/aurora.js/f0b6478:
+    resolution: {tarball: https://codeload.github.com/aurora-is-near/aurora.js/tar.gz/f0b6478}
     name: '@aurora-is-near/engine'
     version: 0.0.0
     dependencies:

--- a/src/aurora.ts
+++ b/src/aurora.ts
@@ -110,7 +110,7 @@ async function main(argv: string[], env: NodeJS.ProcessEnv) {
     .command('get-bridge-prover')
     .action(async (options, command) => {
       const [_, engine] = await loadConfig(command, options, env);
-      const accountID = (await engine.getBridgeProvider()).unwrap();
+      const accountID = (await engine.getBridgeProver()).unwrap();
       const p = new Table();
       p.addRow({ bridge_prover: accountID.toString() });
       p.printTable();


### PR DESCRIPTION
### Before

```
$ node lib/aurora.js get-bridge-prover --network testnet
/Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/near-api-js@0.39.0/node_modules/near-api-js/lib/providers/json-rpc-provider.js:80
            throw new errors_1.TypedError(`Querying ${args} failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`, rpc_errors_1.getErrorTypeFromErrorMessage(result.error));
                  ^

TypedError: Querying [object Object] failed: wasm execution failed with error: FunctionCallError(MethodResolveError(MethodNotFound)).
{
  "block_hash": "7JMeVtzFmszbLzm3gWnyNQwthJ2WyLd3hP9NWze2sEjC",
  "block_height": 98628243,
  "error": "wasm execution failed with error: FunctionCallError(MethodResolveError(MethodNotFound))",
  "logs": []
}
    at JsonRpcProvider.query (/Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/near-api-js@0.39.0/node_modules/near-api-js/lib/providers/json-rpc-provider.js:80:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Engine.callFunction (file:///Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/github.com+aurora-is-near+aurora.js@ee7dd4c/node_modules/@aurora-is-near/engine/lib/engine.js:310:32)
    at async Engine.getBridgeProvider (file:///Users/pavel/dev/aurora/aurora-cli/node_modules/.pnpm/github.com+aurora-is-near+aurora.js@ee7dd4c/node_modules/@aurora-is-near/engine/lib/engine.js:161:17)
    at async Command.<anonymous> (file:///Users/pavel/dev/aurora/aurora-cli/lib/aurora.js:71:28) {
  type: 'UntypedError',
  context: undefined
}
```

### After
```
$ node lib/aurora.js get-bridge-prover --network testnet
┌───────────────────────┐
│         bridge_prover │
├───────────────────────┤
│ prover.goerli.testnet │
└───────────────────────┘
```